### PR TITLE
test(animate): Set QUnit reorder option false

### DIFF
--- a/test/js/animate.test.js
+++ b/test/js/animate.test.js
@@ -1,3 +1,5 @@
+QUnit.config.reorder = false;
+
 module("Absolute animate Test", {
 	beforeEach : function() {
 		this.egAnimate = eg.invoke("animate",[jQuery,window]);
@@ -109,6 +111,7 @@ if ( navigator.userAgent.indexOf("PhantomJS") == -1 ) {
 						$.each(expected[1], function(i) {
 							expected[1][i] = parseFloat(expected[1][i]).toFixed(3);
 							result[1][i] = parseFloat(result[1][i]).toFixed(3);
+							result[1][i] = (result[1][2] === "-0.000")? "0.000": result[1][i];
 						});
 
 						equal(result[1].toString(), expected[1].toString());

--- a/test/js/animate.test.js
+++ b/test/js/animate.test.js
@@ -109,9 +109,8 @@ if ( navigator.userAgent.indexOf("PhantomJS") == -1 ) {
 						// Ignore very tiny difference. 
 						// Because output matrixes can be different with input matrixes.) 
 						$.each(expected[1], function(i) {
-							expected[1][i] = parseFloat(expected[1][i]).toFixed(3);
-							result[1][i] = parseFloat(result[1][i]).toFixed(3);
-							result[1][i] = (result[1][2] === "-0.000")? "0.000": result[1][i];
+							expected[1][i] = parseFloat(parseFloat(expected[1][i]).toFixed(3));
+							result[1][i] = parseFloat(parseFloat(result[1][i]).toFixed(3));
 						});
 
 						equal(result[1].toString(), expected[1].toString());


### PR DESCRIPTION
## Details
Set QUnit reorder option false.
Adjust value. because only IE makes negative zero string. This makes test failure on IE.


## Reference
#31 

## Preferred reviewer
@netil  @jongmoon   