### PR TITLE
docs(index): change korean doc link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     - Latest : https://egjs.github.io/latest/doc
     - For specific version : `https://egjs.github.io/[VERSION]/doc`
 
-- [한국어(Korean) readme](egjs/egjs/README-ko.md)
+- [한국어(Korean) readme](https://github.com/egjs/egjs/blob/master/README-ko.md)
 
 ### Components
 * **eg** : Collection of base utilities, which are used in diverse egjs components.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     - Latest : https://egjs.github.io/latest/doc
     - For specific version : `https://egjs.github.io/[VERSION]/doc`
 
-- [한국어(Korean) readme](README-ko.md)
+- [한국어(Korean) readme](egjs/egjs/README-ko.md)
 
 ### Components
 * **eg** : Collection of base utilities, which are used in diverse egjs components.


### PR DESCRIPTION
## Issue
egjs/egjs.github.io/issues/2

## Details
Although It has README-ko.md It have broken korean link in API document.
So I changed korean document link path.

## Preferred reviewers
@taihoon-kim @sculove 
