### PR TITLE
fix(component): initialize options property

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -14,6 +14,7 @@ eg.module("component", [eg], function(ns) {
 			// The reference count does not support yet.
 			// this.constructor.$count = (this.constructor.$count || 0) + 1;
 			this.eventHandler = {};
+			this.options = {};
 		},
 		/**
 		 * Get or set option.

--- a/test/js/component.test.js
+++ b/test/js/component.test.js
@@ -353,6 +353,26 @@ test("Option method should be support 4 features.",function(){
 	});
 });
 
+test("The error should not occur without initialization of options property in SubClass construct of Component.",function(){
+	//Given
+	var result = true;
+	var MyClass = eg.Class.extend(eg.Component,{
+		"construct" : function(option){
+			this.option(option);
+		}
+	});
+	//When
+	try{
+		var oMC = new MyClass({
+			"foo" : 1
+		});
+	}catch(e){
+		result = false;
+	}
+	//Then
+	ok(result);
+});
+
 module("instance method", {
 	setup : function(){
 		this.oClass = new TestClass();


### PR DESCRIPTION
## Issue
#51 

## Details
The required initiallization of options property was missing.
So I put the initialization code.
Pull my code or write example to the api doc.(See the code below)
```javascript
var MyComponent = eg.Class.extend(eg.Component,{
  "construct" : function(option){
    // initialize options property here
    this.options = option;
  }
});
```

## Preferred reviewers
@sculove @taihoon-kim 